### PR TITLE
FIX: could not open FiraCode-Regular file

### DIFF
--- a/ligaturize.py
+++ b/ligaturize.py
@@ -60,7 +60,7 @@ def split_camel_case(str):
     return acc
 
 config = {
-    'firacode_ttf': 'FiraCode-Regular.otf',
+    'firacode_ttf': 'FiraCode-Medium.otf',
 
     'add_ligatures': [
         {   # <-


### PR DESCRIPTION
I cloned your repo and ran the ligaturize file but it gave me an error saying it could not open `config['firacode_ttf']`
That's because it could not find the Regular version of FiraCode in the repo, I fixed it to use Medium version which is included along with the repo.